### PR TITLE
feat: Update base image to Stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM buildpack-deps:jessie-curl
+FROM buildpack-deps:stretch-curl
 
-RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
-RUN echo 'deb http://nginx.org/packages/mainline/debian/ jessie nginx' >> /etc/apt/sources.list
+RUN apt-get update && apt-get install wget &&  wget http://nginx.org/keys/nginx_signing.key && apt-key add nginx_signing.key
+RUN echo 'deb http://nginx.org/packages/mainline/debian/ stretch nginx' >> /etc/apt/sources.list
 RUN apt-get update && \
     apt-get install -y nginx-nr-agent && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Jessie base images have APT changes that may not work anymore.
Updated to Debian Stretch